### PR TITLE
Add HDBSCAN/Agglomerative clustering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repository contains the following files:
 - **`ML and Board Games.pdf`**: A presentation detailing the project objectives, implementation, and conclusions.
 - **`MLClusteringBG.ipynb`**: The Jupyter Notebook containing detailed steps for data cleaning, exploratory data analysis, data preprocessing, data modeling and clustering analysis for the recommender system.
 - **`boardgamesdf.csv`**: A preprocessed dataset containing information about board games, including their names, ratings, weights, min/max number of players, and other features. This dataset is generated as the output of the `MLClusteringBG.ipynb` notebook and serves as the primary data source for the recommender system.
+- **`cluster_models.py`**: Utility script that computes additional clustering labels (Agglomerative and HDBSCAN) and prints clustering metrics.
   
 ---
 
@@ -44,6 +45,7 @@ To run this project, ensure you have the following installed:
 
 - 🐍 Python 3.8 or above
 - 📦 pip (Python package installer)
+- 🔍 `hdbscan` library for advanced clustering (included in `requirements.txt`)
 
 You can find the specific dependencies in the `requirements.txt` file.
 
@@ -90,7 +92,14 @@ You can find the specific dependencies in the `requirements.txt` file.
    ```bash
    streamlit run app.py
 
-6. 🛑 **Deactivate the Virtual Environment**:
+6. *(Optional)* **Precompute Clusters**:
+   If you want to save cluster labels to a new CSV file before running the app,
+   execute `cluster_models.py`:
+   ```bash
+   python cluster_models.py
+   ```
+
+7. 🛑 **Deactivate the Virtual Environment**:
    If you no longer need the virtual environment, deactivate it by running:
    ```bash
    deactivate
@@ -102,10 +111,14 @@ You can find the specific dependencies in the `requirements.txt` file.
 1. **Launch the App**:
    Follow the setup instructions to start the Streamlit application.
 
-2. **Select a Board Game**:
+2. **Choose a Clustering Method**:
+   - Use the dropdown in the sidebar to select **KMeans**, **Agglomerative**, or **HDBSCAN**.
+   - The method with the highest silhouette score is pre-selected automatically.
+
+3. **Select a Board Game**:
    - Use the dropdown menu in the app to choose a board game.
 
-3. **View Recommendations**:
+4. **View Recommendations**:
    - The application displays the top 10 rated games similar to your selection.
    - Recommendations are based on clustering analysis of game features.
      

--- a/app.py
+++ b/app.py
@@ -1,19 +1,70 @@
 import streamlit as st
 import pandas as pd
 import numpy as np
-from sklearn.metrics.pairwise import cosine_similarity
+from sklearn.cluster import KMeans, AgglomerativeClustering
+from sklearn.metrics import silhouette_score, davies_bouldin_score, calinski_harabasz_score
+import hdbscan
 
 st.title('Recommender System for Board Games')
 st.write('This app provides board games recommendations based on clustering analysis')
 
-df = pd.read_csvdf = pd.read_csv("boardgamesdf.csv")
+# Load data
+df = pd.read_csv("boardgamesdf.csv")
 
+# Prepare feature matrix (exclude identifiers and rating)
+feature_cols = [c for c in df.columns if c not in ['bggid', 'name', 'avgrating']]
+X = df[feature_cols]
+
+# Compute clustering labels
+labels_kmeans = KMeans(n_clusters=4, random_state=42).fit_predict(X)
+labels_agg = AgglomerativeClustering(n_clusters=4).fit_predict(X)
+labels_hdb = hdbscan.HDBSCAN(min_cluster_size=15).fit_predict(X)
+
+# Store labels in dataframe
+df['Cluster_KMeans'] = labels_kmeans
+df['Cluster_Agglomerative'] = labels_agg
+df['Cluster_HDBSCAN'] = labels_hdb
+
+# Calculate metrics
+
+def calc_metrics(data, labels):
+    if len(np.unique(labels)) <= 1:
+        return -1, np.inf, -1
+    sil = silhouette_score(data, labels)
+    db = davies_bouldin_score(data, labels)
+    ch = calinski_harabasz_score(data, labels)
+    return sil, db, ch
+
+metrics = {
+    'KMeans': calc_metrics(X, labels_kmeans),
+    'Agglomerative': calc_metrics(X, labels_agg),
+    'HDBSCAN': calc_metrics(X, labels_hdb),
+}
+
+best_method = max(metrics, key=lambda m: metrics[m][0])
+
+method = st.selectbox(
+    'Select clustering method:',
+    ['KMeans', 'Agglomerative', 'HDBSCAN'],
+    index=['KMeans', 'Agglomerative', 'HDBSCAN'].index(best_method)
+)
 
 selected_name = st.selectbox('Select a board game:', df['name'].unique())
 
+cluster_col = {
+    'KMeans': 'Cluster_KMeans',
+    'Agglomerative': 'Cluster_Agglomerative',
+    'HDBSCAN': 'Cluster_HDBSCAN'
+}[method]
+
 if selected_name:
-    selected_cluster = df[df['name'] == selected_name]['Cluster'].values[0]
-    recommendations = df[(df['Cluster'] == selected_cluster) & (df['name'] != selected_name)]
+    selected_cluster = df.loc[df['name'] == selected_name, cluster_col].values[0]
+    recommendations = df[(df[cluster_col] == selected_cluster) & (df['name'] != selected_name)]
     top_recommendations = recommendations.sort_values(by='avgrating', ascending=False).head(10)
-    st.write(f"Top 10 games similar to '{selected_name}':")
+    st.write(f"Top 10 games similar to '{selected_name}' using {method}:")
     st.dataframe(top_recommendations[['bggid', 'name', 'avgrating', 'gameweight']])
+
+st.write('---')
+st.write('Clustering metrics:')
+for m, (sil, db, ch) in metrics.items():
+    st.write(f"{m}: silhouette={sil:.3f}, DB={db:.3f}, CH={ch:.3f}")

--- a/cluster_models.py
+++ b/cluster_models.py
@@ -1,0 +1,64 @@
+import pandas as pd
+import numpy as np
+from sklearn.cluster import AgglomerativeClustering
+from sklearn.metrics import silhouette_score, davies_bouldin_score, calinski_harabasz_score
+from sklearn.cluster import KMeans
+import hdbscan
+
+
+def load_features(path="boardgamesdf.csv"):
+    df = pd.read_csv(path)
+    feature_cols = [c for c in df.columns if c not in ['bggid', 'name', 'avgrating', 'Cluster']]
+    X = df[feature_cols]
+    return df, X
+
+
+def cluster_agglomerative(X, n_clusters=4):
+    model = AgglomerativeClustering(n_clusters=n_clusters)
+    labels = model.fit_predict(X)
+    return labels
+
+
+def cluster_hdbscan(X, min_cluster_size=15):
+    model = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size)
+    labels = model.fit_predict(X)
+    return labels
+
+
+def compute_metrics(X, labels):
+    if len(np.unique(labels)) <= 1:
+        return None, None, None
+    sil = silhouette_score(X, labels)
+    db = davies_bouldin_score(X, labels)
+    ch = calinski_harabasz_score(X, labels)
+    return sil, db, ch
+
+
+def main():
+    df, X = load_features()
+    # existing KMeans clusters
+    if 'Cluster' in df.columns:
+        km_labels = df['Cluster'].values
+        sil_km, db_km, ch_km = compute_metrics(X, km_labels)
+        print(f"KMeans -> silhouette: {sil_km:.4f}, DB: {db_km:.4f}, CH: {ch_km:.4f}")
+    else:
+        km_labels = KMeans(n_clusters=4, random_state=42).fit_predict(X)
+        df['Cluster'] = km_labels
+        sil_km, db_km, ch_km = compute_metrics(X, km_labels)
+        print(f"KMeans -> silhouette: {sil_km:.4f}, DB: {db_km:.4f}, CH: {ch_km:.4f}")
+
+    agg_labels = cluster_agglomerative(X)
+    df['Cluster_Agglomerative'] = agg_labels
+    sil_agg, db_agg, ch_agg = compute_metrics(X, agg_labels)
+    print(f"Agglomerative -> silhouette: {sil_agg:.4f}, DB: {db_agg:.4f}, CH: {ch_agg:.4f}")
+
+    hdb_labels = cluster_hdbscan(X)
+    df['Cluster_HDBSCAN'] = hdb_labels
+    sil_hdb, db_hdb, ch_hdb = compute_metrics(X, hdb_labels)
+    print(f"HDBSCAN -> silhouette: {sil_hdb:.4f}, DB: {db_hdb:.4f}, CH: {ch_hdb:.4f}")
+
+    df.to_csv('boardgamesdf_with_clusters.csv', index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -405,3 +405,4 @@ zict @ file:///C:/Users/dev-admin/perseverance-python-buildout/croot/zict_169954
 zipp @ file:///C:/Users/dev-admin/perseverance-python-buildout/croot/zipp_1707493775475/work
 zope.interface @ file:///C:/Users/dev-admin/perseverance-python-buildout/croot/zope.interface_1699497164709/work
 zstandard @ file:///C:/b/abs_e46tf0_91g/croot/zstandard_1714678303615/work
+hdbscan


### PR DESCRIPTION
## Summary
- provide a utility `cluster_models.py` to run AgglomerativeClustering and HDBSCAN and calculate clustering metrics
- enhance `app.py` with optional clustering methods and show metrics
- document new script and usage in README
- require `hdbscan` library

## Testing
- `python -m py_compile cluster_models.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_685d45e5398c832380713beb1dec1558